### PR TITLE
Fix pgcluu_collectd to stop capturing activity when option -C is omitted...

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -673,7 +673,7 @@ while (1) {
 	# If counter reached then exit
 	$tcounter++;
 
-	if ($tcounter > $END_AFTER_COUNTER) {
+	if (($END_AFTER_COUNTER > 0) && ($tcounter > $END_AFTER_COUNTER)) {
 		&dprint("LOG: counter reached, terminating.\n");
 		if (-f $PIDFILE) {
 			unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");


### PR DESCRIPTION
....

Bug was introduced in commit aa19e3bd8f91414bbb5990de8595bacd872f2f0b.
