### PR TITLE
Fix for sar command when ssh not in use

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -683,7 +683,7 @@ if ($tcounter == 3) {
 	# Set the sar command
 	my $sar_command = '';
 	if (!$DISABLE_SAR) {
-		$sar_command = $sshcmd . ' "' . $def_sar_command . "\"" if ($sshcmd);
+		$sar_command = ($sshcmd) ? $sshcmd . ' "' . $def_sar_command . ' "' : $def_sar_command;
 		$sar_command .= " >>$OUT_DIR/$SAR_FILE";
 	}
 


### PR DESCRIPTION
I switched from v2.3 to master to use the new rotation option for pgcluu_collectd. When I switched, I found that sar stopped working. I traced the problem to a conditional for the sar command when not using ssh. The conditional was returning empty when $sshcmd wasn't defined.