### PR TITLE
Add timezone option for perl localtime()

### DIFF
--- a/pgcluu
+++ b/pgcluu
@@ -23,36 +23,37 @@ setlocale(LC_ALL, 'C');
 $VERSION = '2.3';
 $PROGRAM = 'pgCluu';
 
-my $OUTPUT_DIR  = '';
-my $SADF_PROG   = '/usr/bin/sadf';
-my $DISABLE_SAR = 0;
-my $HTML        = '';
-my $NO_TB_STAT  = 0;
-my @INCLUDE_DB  = ();
-my @INCLUDE_TB  = ();
-my @INCLUDE_DEV = ();
-my @INCLUDE_IFACE = ();
-my $IMG_FORMAT  = 'png';
-my $FH          = undef;
-my %DEVFH       = ();
-my $IDX         = 1;
-my $HELP        = 0;
-my $SHOW_VER    = 0;
-my $DEBUG       = 0;
-my $BEGIN       = '';
-my $END         = '';
-my $NUMBER_CPU  = 0;
-my $TIMEZONE    = '00';
-my $REVERT_DATE = 0;
-my $FROM_SA_FILE= 0;
-my $SADC_INPUT_FILE    = '';
-my $SAR_INPUT_FILE     = '';
-my @DEVICE_LIST        = ();
-my @IFACE_LIST         = ();
-my %OVERALL_STATS      = ();
-my @GRAPH_COLORS       = ('#6e9dc9', '#f4ab3a', '#ac7fa8', '#8dbd0f'); 
-my $ZCAT_PROG = '/bin/zcat';
-my $INTERVAL  = 1;
+my $OUTPUT_DIR      = '';
+my $SADF_PROG       = '/usr/bin/sadf';
+my $DISABLE_SAR     = 0;
+my $HTML            = '';
+my $NO_TB_STAT      = 0;
+my @INCLUDE_DB      = ();
+my @INCLUDE_TB      = ();
+my @INCLUDE_DEV     = ();
+my @INCLUDE_IFACE   = ();
+my $IMG_FORMAT      = 'png';
+my $FH              = undef;
+my %DEVFH           = ();
+my $IDX             = 1;
+my $HELP            = 0;
+my $SHOW_VER        = 0;
+my $DEBUG           = 0;
+my $BEGIN           = '';
+my $END             = '';
+my $NUMBER_CPU      = 0;
+my $TIMEZONE        = '00';
+my $STATS_TIMEZONE  = '00';
+my $REVERT_DATE     = 0;
+my $FROM_SA_FILE    = 0;
+my $SADC_INPUT_FILE = '';
+my $SAR_INPUT_FILE  = '';
+my @DEVICE_LIST     = ();
+my @IFACE_LIST      = ();
+my %OVERALL_STATS   = ();
+my @GRAPH_COLORS    = ('#6e9dc9', '#f4ab3a', '#ac7fa8', '#8dbd0f'); 
+my $ZCAT_PROG       = '/bin/zcat';
+my $INTERVAL        = 1;
 
 my %RELKIND = (
 	'r' => 'tables',
@@ -711,25 +712,26 @@ my @dev_opts = ();
 my @tbs_opts = ();
 my @net_opts = ();
 GetOptions(
-	"b|begin=s"      => \$BEGIN,
-	"d|db-only=s"    => \@dbs_opts,
-	"D|device-only=s"=> \@dev_opts,
-	"e|end=s"        => \$END,
-	"h|help!"        => \$HELP,
-	"i|sar-file=s"   => \$SAR_INPUT_FILE,
-	"I|sadc-file=s"  => \$SADC_INPUT_FILE,
-	"n|top-number=i" => \$TOP_STAT,
-	"N|network-only=s" => \@net_opts,
-	"o|output=s"     => \$OUTPUT_DIR,
-	"s|sadf=s"       => \$SADF_PROG,
-	"r|reverse-date" => \$REVERT_DATE,
-	"S|disable-sar!" => \$DISABLE_SAR,
-	"t|with-table=s" => \@tbs_opts,
-	"T|no-table!"    => \$NO_TB_STAT,
-	"v|verbose!"     => \$DEBUG,
-	"V|version!"     => \$SHOW_VER,
-	"z|timezone=s"   => \$TIMEZONE,
-	"from-sa-file!"  => \$FROM_SA_FILE,
+	"b|begin=s"          => \$BEGIN,
+	"d|db-only=s"        => \@dbs_opts,
+	"D|device-only=s"    => \@dev_opts,
+	"e|end=s"            => \$END,
+	"h|help!"            => \$HELP,
+	"i|sar-file=s"       => \$SAR_INPUT_FILE,
+	"I|sadc-file=s"      => \$SADC_INPUT_FILE,
+	"n|top-number=i"     => \$TOP_STAT,
+	"N|network-only=s"   => \@net_opts,
+	"o|output=s"         => \$OUTPUT_DIR,
+	"s|sadf=s"           => \$SADF_PROG,
+	"r|reverse-date"     => \$REVERT_DATE,
+	"S|disable-sar!"     => \$DISABLE_SAR,
+	"t|with-table=s"     => \@tbs_opts,
+	"T|no-table!"        => \$NO_TB_STAT,
+	"v|verbose!"         => \$DEBUG,
+	"V|version!"         => \$SHOW_VER,
+	"z|timezone=s"       => \$TIMEZONE,
+	"Z|stats-timezone=s" => \$STATS_TIMEZONE,
+	"from-sa-file!"      => \$FROM_SA_FILE,
 ) or die usage();
 &usage if ($HELP);
 
@@ -1053,41 +1055,44 @@ usage: $0 [options] [-i sar_file | -I sadc_file] [input_dir]
 		   files are stored.
 
 options:
-  -b, --begin  datetime    start date/time for the data to be parsed.
-  -d, --db-only dbname     Only report for the whole cluster and the given
-			   database name. You can use it multiple time or
-			   give a comma separated list of database name.
-  -D, --device-only dev    only report I/O stats for a particular device
-			   You can use it multiple time or give a comma
-			   separated list of device name, ex: sda,sdc.
-  -e, --end    datetime    end date/time for the data to be parsed.
-  -i, --sar-file=FILE      path to the sar text data file to read to generate
-			   system reports. Default to input_dir/sar_stats.dat.
-  -I, --sadc-file=FILE     sadc binary data file to read to generate system
-			   reports. Default to input_dir/sadc_stats.dat.
-  -n, --top-number         Top number of tables or indexes I/O stats to show.
-			   Default is set to top 10. Set it to 0 to show all.
-  -N, --network-only iface only report stats for a particular network interface.
-			   You can use it multiple times or give a comma separated
-			   list of network interfaces, ex: eth0,eth1.
-  -o, --output=DIR         output directory
-  -r, --reverse-date       By default pgcluu look at mm/dd/yy format in sar file.
-                           When enabled pgcluu will look at dd/mm/yy format.
-  -s, --sadf=BIN           path to the sadf sysstat command used to read the
-                           sadc binary data file. Default: $SADF_PROG.
-  -S, --disable-sar        disable collect of system statistics with sar.
-  -t, --with-table table   Only report for the whole tables and the given
-			   table name. You can use it multiple time or
-			   give a comma separated list of database name.
-  -T, --no-table           Do not report statistics related to tables.
-  -v, --verbose            Print out debug informations.
-  -V, --version            Show pgcluu version and exit.
-  -z, --timezone +/-XX     Set the number of hour(s) from GMT of the timezone.
-                           Use this to adjust date/time from the sar output,
-                           pgcluu use GMT time to draw charts.
-  --from-sa-file           instruct pgcluu that file specified by the -i option
-                           uses the standard system activity daily data file.
-  --help                   print usage
+  -b, --begin  datetime      start date/time for the data to be parsed.
+  -d, --db-only dbname       Only report for the whole cluster and the given
+                             database name. You can use it multiple time or
+                             give a comma separated list of database name.
+  -D, --device-only dev      only report I/O stats for a particular device
+                             You can use it multiple time or give a comma
+                             separated list of device name, ex: sda,sdc.
+  -e, --end    datetime      end date/time for the data to be parsed.
+  -i, --sar-file=FILE        path to the sar text data file to read to generate
+                             system reports. Default to input_dir/sar_stats.dat.
+  -I, --sadc-file=FILE       sadc binary data file to read to generate system
+                             reports. Default to input_dir/sadc_stats.dat.
+  -n, --top-number           Top number of tables or indexes I/O stats to show.
+                             Default is set to top 10. Set it to 0 to show all.
+  -N, --network-only iface   only report stats for a particular network interface.
+                             You can use it multiple times or give a comma separated
+                             list of network interfaces, ex: eth0,eth1.
+  -o, --output=DIR           output directory
+  -r, --reverse-date         By default pgcluu look at mm/dd/yy format in sar file.
+                             When enabled pgcluu will look at dd/mm/yy format.
+  -s, --sadf=BIN             path to the sadf sysstat command used to read the
+                             sadc binary data file. Default: $SADF_PROG.
+  -S, --disable-sar          disable collect of system statistics with sar.
+  -t, --with-table table     Only report for the whole tables and the given
+                             table name. You can use it multiple time or
+                             give a comma separated list of database name.
+  -T, --no-table             Do not report statistics related to tables.
+  -v, --verbose              Print out debug informations.
+  -V, --version              Show pgcluu version and exit.
+  -z, --timezone +/-XX       Set the number of hour(s) from GMT of the timezone.
+                             Use this to adjust date/time from the sar output,
+                             pgcluu use GMT time to draw charts.
+  -Z, --stats-timezone +/-XX Set the number of hour(s) from GMT of the timezone.
+                             Use this to adjust date/time from the cluster and
+                             system stats output, pgcluu use GMT time.
+  --from-sa-file             instruct pgcluu that file specified by the -i option
+                             uses the standard system activity daily data file.
+  --help                     print usage
 
 For example, you can generate all HTML reports from data files stored into
 /tmp/stat_db1/ with the following commands:
@@ -4368,13 +4373,14 @@ sub generate_html_index
 
     <div id="home"><br/><br/><br/></div>
 EOF
+	my $tz = ((0-$STATS_TIMEZONE)*3600);
 	if (exists $OVERALL_STATS{'start_date'}) {
-		$OVERALL_STATS{'start_date'} = localtime($OVERALL_STATS{'start_date'}/1000);
-		$OVERALL_STATS{'end_date'} = localtime($OVERALL_STATS{'end_date'}/1000);
+		$OVERALL_STATS{'start_date'} = localtime($OVERALL_STATS{'start_date'}/1000 + $tz);
+		$OVERALL_STATS{'end_date'} = localtime($OVERALL_STATS{'end_date'}/1000 + $tz);
 	}
 	if (exists $OVERALL_STATS{'sar_start_date'}) {
-		$OVERALL_STATS{'sar_start_date'} = localtime($OVERALL_STATS{'sar_start_date'}/1000);
-		$OVERALL_STATS{'sar_end_date'} = localtime($OVERALL_STATS{'sar_end_date'}/1000);
+		$OVERALL_STATS{'sar_start_date'} = localtime($OVERALL_STATS{'sar_start_date'}/1000 + $tz);
+		$OVERALL_STATS{'sar_end_date'} = localtime($OVERALL_STATS{'sar_end_date'}/1000 + $tz);
 	}
 	if (exists $OVERALL_STATS{'cluster'}) {
 		$OVERALL_STATS{'cluster'}{'size'} ||= 0;


### PR DESCRIPTION
Add separate timezone option for perl localtime(), which is being used to generate dates for cluster and system stats.