### PR TITLE
[FIX] no statements statistics menu entry

### DIFF
--- a/pgcluu
+++ b/pgcluu
@@ -4956,7 +4956,6 @@ sub pg_stat_statements
 {
 	my ($in_dir, $file) = @_;
 
-	my %all_stat_statements = ();
 	my $total_val = 0;
 	my @start_vals = ();
 	my $has_temp = 0;


### PR DESCRIPTION
when `pg_stat_statements` module is enabled and installed as an extension on a database, `pgcluu` is still not able to generate the correct report entry in `Statements statistics` menu.

I removed the local `all_stat_statements` to use the global one and make it available later to generate the report.