### PR TITLE
Use psql -X so .psqlrc doesn't get in the way

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -627,7 +627,7 @@ print OUT $$;
 close(OUT);
 
 # Generate the psql command
-$PSQL_PROG .= " -Atq -F';' -f - ";
+$PSQL_PROG .= " -XAtq -F';' -f - ";
 my $PGBOUNCER_PROG = $PSQL_PROG . ' ' . $PGBOUNCER_ARGS . ' pgbouncer';
 
 if ($NO_DATABASE) {


### PR DESCRIPTION
If .psqlrc contains for example \timing, pgcluu_collectd will get
confused.