### PR TITLE
Detect partitions and summarize information in a dedicated report

### DIFF
--- a/pgcluu
+++ b/pgcluu
@@ -2054,10 +2054,15 @@ sub write_database_info
 	return if (($#INCLUDE_DB >= 0) && (!grep($db =~ /^$_$/, @INCLUDE_DB)));
 
 	my $next = $#{$sysinfo{EXTENSION}{$db}} + 1;
-	my $extlist = join(',', @{$sysinfo{EXTENSION}{$db}});
+	my $extlist = join(', ', @{$sysinfo{EXTENSION}{$db}});
 	$extlist = ' (' . $extlist . ')' if ($extlist);
+	my $nparts = 0;
+	$nparts = scalar keys %{$sysinfo{PARTITIONNED_TABLE}{$db}} if (exists $sysinfo{PARTITIONNED_TABLE}{$db});
+	my $partlist = '';
+	$partlist = join(', ', keys %{$sysinfo{PARTITIONNED_TABLE}{$db}}) if ($nparts > 0);
+	$partlist = '(' . $partlist . ')' if ($partlist);
 	my $nsch = $#{$sysinfo{SCHEMA}{$db}} + 1;
-	my $schlist = join(',', @{$sysinfo{SCHEMA}{$db}});
+	my $schlist = join(', ', @{$sysinfo{SCHEMA}{$db}});
 	$schlist = ' (' . $schlist . ')' if ($schlist);
 	my $procount = $sysinfo{PROCEDURE}{$db} || 0;
 	my $trigcount = $sysinfo{TRIGGER}{$db} || 0;
@@ -2093,6 +2098,7 @@ sub write_database_info
 		<li></li>
 	        <li><span class="figure">$dbsize</span> <span class="figure-label">Total size</span></li>
 	        <li><span class="figure">$next</span> <span class="figure-label">Installed extensions$extlist</span></li>
+	        <li><span class="figure">$nparts</span> <span class="figure-label">Partitionned tables$partlist</span></li>
 	        <li><span class="figure">$OVERALL_STATS{database}{$db}{unlogged}</span> <span class="figure-label">Unlogged tables</span></li>
 	        <li><span class="figure">$OVERALL_STATS{database}{$db}{invalid_indexes}</span> <span class="figure-label">Invalid indexes</span></li>
 	        <li><span class="figure">$OVERALL_STATS{database}{$db}{hash_indexes}</span> <span class="figure-label">Hash indexes</span></li>
@@ -2116,6 +2122,68 @@ sub write_database_info
 }
 	);
 
+	if ($nparts > 0) {
+		$dbfh->print( qq{
+<li class="slide" id="partitionned-table-slide">
+  <div id="partitionned-tbl"><br/><br/><br/></div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <i class="fa fa-desktop fa-2x pull-left fa-border"></i><h2>Partitionned tables in database $db</h2>
+        </div>
+        <div class="panel-body">
+}
+		);
+		foreach my $oid (sort(keys %{$sysinfo{PARTITIONNED_TABLE}{$db}})) {
+			$dbfh->print( qq{
+          <div class="analysis-item row-fluid" id="part-tbl-$oid">
+            <div class="span11">
+              <h3>$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{name}</h3>
+              <div class="key-figures">
+                <ul>
+                  <li>Partitionning kind: <span class="figure">$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{kind}</span></li>
+                  <li>Number of partitions: <span class="figure">$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{nparts}</span></li>
+                  <li>$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{kind} detail: <pre>$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{implementation}</pre></li>
+                </ul>
+              </div>
+              <table class="table table-striped sortable" id="part-tbl-$oid-table">
+                <thead>
+                  <tr>
+                    <th>Partition name</th>
+                    <th>Constraint</th>
+                  </tr>
+                </thead>
+                <tbody>
+}
+			);
+
+			foreach my $part (sort(keys %{$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{child}})) {
+				$dbfh->print( qq{
+                  <tr>
+                    <td>$part</td>
+                    <td>$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{child}{$part}</td>
+                  </tr>
+}
+				);
+			}
+			$dbfh->print( qq{
+              </table>
+            </div>
+          </div>
+}
+			);
+        }
+		$dbfh->print( qq{
+        </div>
+      </div>
+    </div>
+  </div>
+</li>
+}
+		);
+
+	}
 }
 
 sub compute_postgresql_stat
@@ -6582,6 +6650,12 @@ EOF
 			my $extlist = join(', ', @{$OVERALL_STATS{'cluster'}{'extensions'}});
 			$extensions_info = qq{<li><span class="figure">$extnum</span> <span class="figure-label">Extensions ($extlist)</span></li>};
 		}
+		my $nparts = $#{$OVERALL_STATS{'cluster'}{'partitionned_tables'}} + 1;
+		my $parts_info = '';
+		if ($nparts) {
+			my $partlist = join(', ', @{$OVERALL_STATS{'cluster'}{'partitionned_tables'}});
+			$parts_info = qq{<li><span class="figure">$nparts</span> <span class="figure-label">Partitioned tables ($partlist)</span></li>};
+			}
 		$sysinfo{PGVERSION}{'full_version'} ||= '';
 		$sysinfo{PGVERSION}{'uptime'} ||= '';
 		my $database_number = scalar keys %{$OVERALL_STATS{'database'}};
@@ -6636,6 +6710,7 @@ EOF
 		$temp_file_info
 		$deadlock_info
 		$extensions_info
+		$parts_info
 		$bgwriter_reset
 		</ul>
 		</div>
@@ -7523,6 +7598,12 @@ sub generate_html_menu
 		      <li id="menu-database-info"><a href="database-$db.html#database-info">Database info</a></li>
 };
 		}
+
+		my $disable_parttables = ' class="disabled"';
+		$disable_parttables = '' if (defined $sysinfo{PARTITIONNED_TABLE}{$db});
+		$menu_str .= qq{
+		    <li id="menu-partitionned-tbl"$disable_parttables><a href="database-$db.html#partitionned-tbl">Partitionned Tables</a></li>
+};
 
 		my %data_info = %{$DB_GRAPH_INFOS{'pg_stat_user_tables.csv'}};
 		my $table_str = '';
@@ -9803,6 +9884,25 @@ sub read_sysinfo_file
 			my ($USER,$PID,$CPU,$MEM,$VSZ,$RSS,$TTY,$STAT,$START,$TIME,$COMMAND) = split(/\s+/, $l, 11);
 			push(@{$sysinfo{$section}}, '<tr><td>' . join('</td><td>', $USER,$PID,$CPU,$MEM,$VSZ,$RSS,$TTY,$STAT,$START,$TIME,$COMMAND) . '</td></tr>') if ($l !~/^USER/);
 		}
+		if ($section eq 'PARTITIONNED_TABLE') {
+			# limit split to 2 fields, check constraint can contains "="
+			my ($db, $csv) = split(/[=]/, $l, 2);
+
+			if ($csv) {
+				my ($oid, $parent, $child, $constraint, $kind, $nparts ) = split(/[;]+/, $csv);
+				$sysinfo{$section}{$db}{$oid}{name} = $parent;
+				$sysinfo{$section}{$db}{$oid}{child}{$child} = $constraint;
+				$sysinfo{$section}{$db}{$oid}{kind} = $kind;
+				$sysinfo{$section}{$db}{$oid}{nparts} = $nparts;
+				push(@{$OVERALL_STATS{'cluster'}{'partitionned_tables'}}, "$db.$parent") if (!grep(/^$db.$parent/, @{$OVERALL_STATS{'cluster'}{'partitionned_tables'}}));
+			}
+		}
+        if ($section =~ /PARTITION_IMPL (.*) (\d+)/) {
+            my $db = $1;
+            my $oid = $2;
+
+			$sysinfo{PARTITIONNED_TABLE}{$db}{$oid}{implementation} .= "$l\n";
+        }
 	}
 	close(IN);
 

--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -1026,6 +1026,7 @@ sub get_initial_info
 		my @schemas = ();
 		my @procs = ();
 		my @trigs = ();
+		my %parts = ();
 		unless(open(OUT, ">>$OUT_DIR/sysinfo.txt")) {
 			&dprint("FATAL: can not write into file $OUT_DIR/sysinfo.txt\n");
 			exit 1;
@@ -1068,8 +1069,30 @@ sub get_initial_info
 		foreach my $t (@trigs) {
 			print OUT "$t\n";
 		}
-		close(OUT);
+		# Look for partitionned tables in a database
+		print OUT "[PARTITIONNED_TABLE]\n";
+		foreach my $db (sort @alldbs) {
+			my @p = &get_partitionned_tables($db);
 
+			# Get general partition information
+			foreach my $line (@p) {
+				my ($oid, $content) = split(/[;]/, $line, 2);
+
+				$parts{$oid} = $db;
+				print OUT "$db=$oid;$content\n";
+			}
+		}
+		# get trigger or rule definition of each partitionned table
+		for my $oid (keys %parts) {
+			my $db = $parts{$oid};
+			my @implementation = &get_partitionned_implementation($db, $oid);
+
+			print OUT "[PARTITION_IMPL $db $oid]\n";
+			foreach my $line (@implementation) {
+				print OUT "$line\n";
+			}
+		}
+		close(OUT);
 	}
 }
 
@@ -1323,16 +1346,86 @@ sub get_schemas
 	}
 	my @db_schema = `echo "SELECT nspname FROM pg_namespace WHERE nspname !~ '^pg_' AND nspname <> 'information_schema' ORDER BY 1" | $LOCAL_PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp(@db_schema);
 
 	return @db_schema;
+}
+
+####
+## Retrieve partitionned tables from a given database.
+####
+sub get_partitionned_tables
+{
+    my $database = shift;
+	my $LOCAL_PSQL_PROG = $PSQL_PROG;
+
+	if ($database && ($LOCAL_PSQL_PROG !~ s/-d $dbnames[0]/-d $database/i)) {
+		if ($database !~ /^[a-z0-9\_\-]+$/i) {
+			$LOCAL_PSQL_PROG .= " -d '$database'";
+		} else {
+			$LOCAL_PSQL_PROG .= " -d $database";
+		}
+	}
+
+	# Assume that inherited tables having check constraints are partitions
+    my $sql = "SELECT p.oid, quote_ident(pn.nspname) || '.' || quote_ident(p.relname),"
+		. " quote_ident(cn.nspname) || '.' || quote_ident(c.relname), con.consrc,"
+		. " CASE WHEN t.oid IS NOT NULL THEN 'Trigger' WHEN r.oid IS NOT NULL THEN 'Rule' ELSE 'Unknown' END,"
+		. " count(*) OVER (PARTITION BY p.oid)"
+		. " FROM pg_inherits i"
+		. " JOIN pg_class p ON p.oid = i.inhparent"
+		. " JOIN pg_namespace pn ON pn.oid = p.relnamespace"
+		. " JOIN pg_class c ON c.oid = i.inhrelid"
+		. " JOIN pg_namespace cn ON cn.oid = p.relnamespace"
+		. " JOIN pg_constraint con ON con.conrelid= c.oid AND con.contype = 'c'"
+		. " LEFT JOIN pg_trigger t ON t.tgrelid = p.oid"
+		. " LEFT JOIN pg_rewrite r ON r.ev_class = p.oid";
+
+	my @db_parttables = `echo "$sql" | $LOCAL_PSQL_PROG`;
+	if ($? != 0) {
+		unlink_pid_and_exit("FATAL: psql error.", 0);
+	}
+	chomp(@db_parttables);
+
+	return @db_parttables;
+}
+
+###
+# Retrieve trigger or rules of a specific partitionned table from a given database.
+###
+sub get_partitionned_implementation {
+	my $database = shift;
+	my $oid = shift;
+	my $LOCAL_PSQL_PROG = $PSQL_PROG;
+
+	if ($database && ($LOCAL_PSQL_PROG !~ s/-d $dbnames[0]/-d $database/i)) {
+		if ($database !~ /^[a-z0-9\_\-]+$/i) {
+			$LOCAL_PSQL_PROG .= " -d '$database'";
+		} else {
+			$LOCAL_PSQL_PROG .= " -d $database";
+		}
+	}
+
+    my $sql = "SELECT DISTINCT CASE WHEN pro.oid IS NOT NULL THEN pro.prosrc"
+		. "   WHEN r.oid IS NOT NULL THEN pg_get_ruledef(r.oid)"
+		. "   ELSE 'Unknown' END"
+		. " FROM pg_inherits i"
+		. " JOIN pg_class p ON p.oid = i.inhparent"
+		. " JOIN pg_namespace pn ON pn.oid = p.relnamespace"
+		. " LEFT JOIN pg_trigger t ON t.tgrelid = p.oid"
+		. " LEFT JOIN pg_proc pro ON pro.oid = t.tgfoid"
+		. " LEFT JOIN pg_rewrite r ON r.ev_class = p.oid"
+		. " WHERE p.oid = $oid";
+
+	my @db_parttables = `echo "$sql" | $LOCAL_PSQL_PROG`;
+	if ($? != 0) {
+		unlink_pid_and_exit("FATAL: psql error.", 0);
+	}
+	chomp(@db_parttables);
+
+	return @db_parttables;
 }
 
 ####

--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -590,7 +590,7 @@ sub terminate
 		unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");
 	}
 
-        # Wait for all child processes to die except for the logger
+	# Wait for all child processes to die except for the logger
 	&wait_all_childs();
 
 	exit 0;
@@ -694,22 +694,14 @@ while (1) {
 
 	# Search if the monitoring need to stop here
 	if ($END_AFTER && ($t0 > ($START_TIME + $END_AFTER))) {
-		&dprint("LOG: ending time reach, terminating.\n");
-		if (-f $PIDFILE) {
-			unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("LOG: ending time reach, terminating.", 0);
 	}
 
 	# If counter reached then exit
 	$tcounter++;
 
 	if (($END_AFTER_COUNTER > 0) && ($tcounter > $END_AFTER_COUNTER)) {
-		&dprint("LOG: counter reached, terminating.\n");
-		if (-f $PIDFILE) {
-			unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("LOG: counter reached, terminating.", 0);
 	}
 
 	# Some time range may not collect data
@@ -866,11 +858,7 @@ while (1) {
 	my $script_sql = &create_sql_script();
 	if (!$script_sql && ($#METRICS < 0)) {
 		# No action can be perform with this PostgreSQL version
-		if (-f $PIDFILE) {
-			unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");
-		}
-		&dprint("FATAL: no action will be run on this PostgreSQL version $DB_INFO{major}.$DB_INFO{minor}, $!\n");
-		exit 1;
+		unlink_pid_and_exit("FATAL: no action will be run on this PostgreSQL version $DB_INFO{major}.$DB_INFO{minor}, $!", 1);
 	}
 
 	if (!$NO_DATABASE) {
@@ -969,11 +957,7 @@ while (1) {
 			my $lsize = `du -s $OUTPUT_DIR`;
 			chomp($lsize);
 			if ($lsize > $MAX_SIZE) {
-				&dprint("LOG: max size limit reach, terminating.\n");
-				if (-f $PIDFILE) {
-					unlink("$PIDFILE") or &dprint("ERROR: Unable to remove pid file $PIDFILE, $!\n");
-				}
-				exit 0;
+				unlink_pid_and_exit("LOG: max size limit reach, terminating.", 0);
 			}
 		}
 
@@ -1229,12 +1213,7 @@ sub fetch_version
 	if ($? != 0) {
 		# Only stop here if there's no pgbouncer querying
 		if (!$PGBOUNCER_ARGS) {
-			&dprint("FATAL: psql error. $pg_ver\n");
-			# remove the pidfile
-			if (-f $PIDFILE) {
-				unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-			}
-			exit 0;
+			unlink_pid_and_exit("FATAL: psql error. $pg_ver", 0);
 		} else {
 			return -1;
 		}
@@ -1279,12 +1258,7 @@ sub get_extensions
 	}
 	my @db_extension = `echo "SELECT extname||'-'||extversion FROM pg_extension;" | $LOCAL_PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp(@db_extension);
 
@@ -1299,12 +1273,7 @@ sub get_databases
 
 	my @dbs = `echo "SELECT datname FROM pg_database WHERE NOT datistemplate AND datallowconn;" | $PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp(@dbs);
 
@@ -1320,12 +1289,7 @@ sub get_uptime
 
 	my $uptime = `echo "SELECT pg_postmaster_start_time();" | $PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp($uptime);
 
@@ -1379,12 +1343,7 @@ sub has_pg_buffercache
 
 	my $hasit = `echo "SELECT proname FROM pg_proc WHERE proname = 'pg_buffercache_pages';" | $PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp($hasit);
 
@@ -1400,12 +1359,7 @@ sub has_pgstatstatements
 
 	my $hasit = ` echo "SELECT n.nspname||'.'||p.proname FROM pg_proc p, pg_namespace n, pg_settings s WHERE p.proname='pg_stat_statements' AND p.pronamespace=n.oid AND s.name='shared_preload_libraries' AND s.setting LIKE '%pg_stat_statements%';" | $PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp($hasit);
 
@@ -2126,12 +2080,7 @@ sub get_proc_name
 	}
 	my @db_proc = `echo "SELECT n.nspname||'.'||p.proname FROM pg_proc p, pg_namespace n WHERE p.pronamespace=n.oid AND n.nspname NOT IN ('pg_catalog', 'information_schema');" | $LOCAL_PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp(@db_proc);
 
@@ -2153,12 +2102,7 @@ sub get_proc_count
 	}
 	my $db_proc = `echo "SELECT count(p.proname) FROM pg_proc p, pg_namespace n WHERE p.pronamespace=n.oid AND n.nspname NOT IN ('pg_catalog', 'information_schema');" | $LOCAL_PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp($db_proc);
 
@@ -2186,12 +2130,7 @@ sub get_triggers
 	}
 	my $db_trigger = `echo "SELECT count(tgname) FROM pg_trigger WHERE NOT tgisinternal;" | $LOCAL_PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp($db_trigger);
 
@@ -2387,12 +2326,7 @@ sub get_configuration_files
 {
 	my @cfiles = `echo "SELECT setting FROM pg_settings WHERE name IN ('config_file','hba_file','ident_file','data_directory') ORDER BY name;" | $PSQL_PROG`;
 	if ($? != 0) {
-		&dprint("FATAL: psql error.\n");
-		# remove the pidfile
-		if (-f $PIDFILE) {
-			unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
-		}
-		exit 0;
+		unlink_pid_and_exit("FATAL: psql error.", 0);
 	}
 	chomp(@cfiles);
 
@@ -2611,6 +2545,18 @@ sub compress_files
 
 	`$GZIP_PROG $dir/*`;
 
+}
+
+sub unlink_pid_and_exit
+{
+	my ($msg, $rc) = shift;
+
+	&dprint("$msg\n");
+	# remove the pidfile
+	if (-f $PIDFILE) {
+		unlink $PIDFILE or &dprint("ERROR: Unable to remove pidfile: $!\n");
+	}
+	exit $rc;
 }
 
 # Load setting from file pg_settings.csv and pg_db_role_setting.csv into hashrefs


### PR DESCRIPTION
Hello,

I added a new report to get almost all information needed if partitionned tables are found on a cluster:

* parent partition name
* number of partitions
* type of partitionning (for now trigger and rule, "native" should be implemented for pg10) (pg_partman or pg_pathman should be obvious since an extension is needed and thus displayed in pgcluu reports)
* partition implementation (trigger or rule definition)
* list of partitions with their check constraint

I'm very bad at UI, so let me know if the report can be improved in some way, or if there's any issue with the code.