### PR TITLE
Add PageTables information

### DIFF
--- a/cgi-bin/pgcluu.cgi
+++ b/cgi-bin/pgcluu.cgi
@@ -7057,6 +7057,7 @@ EOF
 	      <li><span class="figure">$sysinfo{MEMORY}{'cached'}</span> <span class="figure-label">Cached</span></li>
 	      <li><span class="figure">$sysinfo{MEMORY}{'swaptotal'}</span> <span class="figure-label">Total swap</span></li>
 	      <li><span class="figure">$sysinfo{MEMORY}{'swapfree'}</span> <span class="figure-label">Free swap</span></li>
+	      <li><span class="figure">$sysinfo{MEMORY}{'pagetables'}</span> <span class="figure-label">Page Tables</span></li>
 EOF
 			if (exists $sysinfo{MEMORY}{'shmem'}) {
 				print <<EOF;

--- a/pgcluu
+++ b/pgcluu
@@ -7289,6 +7289,7 @@ EOF
 	      <li><span class="figure">$sysinfo{MEMORY}{'cached'}</span> <span class="figure-label">Cached</span></li>
 	      <li><span class="figure">$sysinfo{MEMORY}{'swaptotal'}</span> <span class="figure-label">Total swap</span></li>
 	      <li><span class="figure">$sysinfo{MEMORY}{'swapfree'}</span> <span class="figure-label">Free swap</span></li>
+	      <li><span class="figure">$sysinfo{MEMORY}{'pagetables'}</span> <span class="figure-label">Page Tables</span></li>
 EOF
 		if (exists $sysinfo{MEMORY}{'shmem'}) {
 			print $fh <<EOF;


### PR DESCRIPTION
Hi Gilles,

This PR add kernel PageTables information. It is the amount of memory used by process to address shared memory : 

> PageTables: Amount of memory dedicated to the lowest level of page tables. This can increase to a high value if a lot of processes are attached to the same shared memory segment.

https://access.redhat.com/solutions/406773

Try a pgbench with `-c 4` and `-c 800`. You'll see ;)

Cheers!