### PR TITLE
set hamburger dropdown menu background from transparent to grey

### DIFF
--- a/cgi-bin/pgcluu.cgi
+++ b/cgi-bin/pgcluu.cgi
@@ -7953,7 +7953,7 @@ AAAASUVORK5CYII=';
           </button>
         </div>
 
-        <div class="navbar-collapse collapse">
+        <div class="navbar-inverse navbar-collapse collapse">
           <ul class="nav navbar-nav">
               <li id="menu-home" class="dropdown"><a href="" onclick="document.location.href='$SCRIPT_NAME?action=home&end='+document.getElementById('end-date').value+'&start='+document.getElementById('start-date').value; return false;">Home</a></li>
 };

--- a/pgcluu
+++ b/pgcluu
@@ -7799,7 +7799,7 @@ sub generate_html_menu
             <span class="icon-bar"></span>
           </button>
         </div>
-        <div class="navbar-collapse collapse">
+        <div class="navbar-inverse navbar-collapse collapse">
           <ul class="nav navbar-nav">
               <li id="menu-home" class="dropdown"><a href="index.html#home">Home</a></li>
 };


### PR DESCRIPTION
visual fix for the drop down menu background of the hamburger menu (narrow screen menu) setting it from transparent to grey to ensure it is readable.