### PR TITLE
Fatal error if the OUTPUT_DIR contains spaces

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -520,6 +520,8 @@ for (my $i = 0; $i <= $#dbhosts; $i++)
 
 # Get the output dir from command line
 my $OUTPUT_DIR = $ARGV[0] || '';
+if ($OUTPUT_DIR =~ / +/) { die "FATAL: $OUTPUT_DIR contains 1 or more spaces - this is not yet supported. \n" }
+
 # Overwrite the output directory in capture mode
 if ($CAPTURE)
 {


### PR DESCRIPTION
Waiting for a real fix of #138, add an error when the output_dir contains a space