### PR TITLE
 Fatal error if the OUTPUT_DIR contains spaces

### DIFF
--- a/pgcluu
+++ b/pgcluu
@@ -1329,7 +1329,7 @@ if (!$CACHE)
 		foreach my $y (sort { $a <=> $b } @years)
 		{
 			print "DEBUG: looking for obsolete directories under $OUTPUT_DIR/$y/\n" if ($DEBUG);
-			`find $OUTPUT_DIR/$y/ -name '*' -mtime +$RETENTION -delete`;
+			`find '$OUTPUT_DIR/$y/' -name '*' -mtime +$RETENTION -delete`;
 		}
 	}
 
@@ -1406,7 +1406,7 @@ foreach (my $dx = 0; $dx <= $#WORK_DIRS; $dx++)
 	} else {
 		$OUTPUT_DIR = "$ORIG_OUTPUT_DIR";
 	}
-	
+
 	# Check if this directory have already been processed
 	if (-e "$OUTPUT_DIR/done")
 	{
@@ -1455,7 +1455,7 @@ foreach (my $dx = 0; $dx <= $#WORK_DIRS; $dx++)
 		# Create output subdirectories if not exists yet
 		if (!$CACHE && !-e "$OUTPUT_DIR")
 		{
-			my $ret = `mkdir -p $OUTPUT_DIR 2>&1`;
+			my $ret = `mkdir -p '$OUTPUT_DIR' 2>&1`;
 			if ($ret) {
 				die "FATAL: $ret\n";
 			}
@@ -1548,7 +1548,7 @@ foreach (my $dx = 0; $dx <= $#WORK_DIRS; $dx++)
 			# if we have binary files and gzipped files, binary files contains all stats
 			elsif (($#binfiles == -1) && -e "$in_dir/$k.gz" && !-z "$in_dir/$k.gz")
 			{
-				&compute_postgresql_stat($in_dir, "$k.gz", $src_base, %{$DB_GRAPH_INFOS{$k}}); 
+				&compute_postgresql_stat($in_dir, "$k.gz", $src_base, %{$DB_GRAPH_INFOS{$k}});
 				push(@statistics_build, $k) if (!grep(/^$k$/, @statistics_build));
 			}
 			# Files use 'all' instead of 'user' with pgcluu_collectd --stat-type option
@@ -1589,7 +1589,7 @@ foreach (my $dx = 0; $dx <= $#WORK_DIRS; $dx++)
 			if ($#statistics_build > 0)
 			{
 				foreach my $k (@statistics_build) {
-					&compute_postgresql_report($k, $src_base, %{$DB_GRAPH_INFOS{$k}}); 
+					&compute_postgresql_report($k, $src_base, %{$DB_GRAPH_INFOS{$k}});
 				}
 			}
 			else
@@ -1617,9 +1617,9 @@ foreach (my $dx = 0; $dx <= $#WORK_DIRS; $dx++)
 					{
 						my $f = $k;
 						$f =~ s/_all_/_user_/;
-						&compute_postgresql_report($f, $src_base, %{$DB_GRAPH_INFOS{$k}}); 
+						&compute_postgresql_report($f, $src_base, %{$DB_GRAPH_INFOS{$k}});
 					} else {
-						&compute_postgresql_report($k, $src_base, %{$DB_GRAPH_INFOS{$k}}); 
+						&compute_postgresql_report($k, $src_base, %{$DB_GRAPH_INFOS{$k}});
 					}
 				}
 			}
@@ -2688,7 +2688,7 @@ sub pg_stat_database_report
 			$fhcluster->close();
 		}
 	}
-	
+
 	foreach my $id (sort {$a <=> $b} keys %data_info)
 	{
 		my %data = ();
@@ -5152,7 +5152,7 @@ sub pgbouncer_ini_report
 	&show_diff($fhcluster, %all_pgbouncer_ini_diff);
 
 	%all_pgbouncer_ini_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -5412,7 +5412,7 @@ sub pg_class_size_report
 			$fhtable->close;
 		}
 	}
-	
+
 	%all_class_size = ();
 }
 
@@ -5991,7 +5991,7 @@ sub postgresql_conf_report
 	&show_diff($fhcluster, %all_postgresql_conf_diff);
 
 	%all_postgresql_conf_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6061,7 +6061,7 @@ sub recovery_conf_report
 	&show_diff($fhcluster, %all_recovery_conf_diff);
 
 	%all_recovery_conf_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6131,7 +6131,7 @@ sub postgresql_auto_conf_report
 	&show_diff($fhcluster, %all_postgresql_auto_conf_diff);
 
 	%all_postgresql_auto_conf_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6203,7 +6203,7 @@ sub pg_hba_conf_report
 	&show_diff($fhcluster, %all_pg_hba_conf_diff);
 
 	%all_pg_hba_conf_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6274,7 +6274,7 @@ sub pg_ident_conf_report
 	&show_diff($fhcluster, %all_pg_ident_conf_diff);
 
 	%all_pg_ident_conf_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6384,7 +6384,7 @@ sub pg_settings_report
 	&show_diff($fhcluster, %all_settings_diff);
 
 	%all_settings_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -6548,7 +6548,7 @@ sub pg_db_role_setting_report
 	&show_diff($fhcluster, %all_db_role_setting_diff);
 
 	%all_db_role_setting_diff = ();
-	
+
 	$fhcluster->close();
 }
 
@@ -7900,7 +7900,7 @@ sub html_footer
   <!-- Modal -->
   <div class="modal fade" id="pgcluuModal" role="dialog">
     <div class="modal-dialog">
-    
+
       <!-- Modal content-->
       <div class="modal-content">
         <div class="modal-header">
@@ -7914,10 +7914,10 @@ sub html_footer
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         </div>
       </div>
-      
+
     </div>
   </div>
-                                                                            
+
     </div><!--/.container-->
   </body>
 </html>
@@ -8979,7 +8979,7 @@ sub compute_cpu_report
 
 			# We only process values from total CPU
 			next if ($cpu ne 'all');
-	
+
 			if (!exists $OVERALL_STATS{'system'}{'cpu'} || ($OVERALL_STATS{'system'}{'cpu'}[1] < $sar_cpu_stat{$t}{$cpu}{total})) {
 				@{$OVERALL_STATS{'system'}{'cpu'}} = ($t, $sar_cpu_stat{$t}{$cpu}{total});
 			}
@@ -9806,7 +9806,7 @@ sub compute_rw_device_report
 	my %devices_stat = ();
 	foreach my $t (sort {$a <=> $b} keys %sar_rw_devices_stat) {
 		foreach my $dev (keys %{$sar_rw_devices_stat{$t}}) {
-			if ($data_info->{name} eq 'system-device') { 
+			if ($data_info->{name} eq 'system-device') {
 				$OVERALL_STATS{'system'}{'devices'}{$dev}{read} += $sar_rw_devices_stat{$t}{$dev}{'rd_sec/s'};
 				$OVERALL_STATS{'system'}{'devices'}{$dev}{write} += $sar_rw_devices_stat{$t}{$dev}{'wr_sec/s'};
 				$devices_stat{$dev}{'rd_sec/s'} .= '[' . $t . ',' . $sar_rw_devices_stat{$t}{$dev}{'rd_sec/s'} . '],';
@@ -9831,7 +9831,7 @@ sub compute_rw_device_report
 			}
 			&html_header($fh, $src_base);
 			$fh->print("<ul id=\"slides\">\n");
-			if ($data_info->{name} eq 'system-device') { 
+			if ($data_info->{name} eq 'system-device') {
 				$devices_stat{$n}{'rd_sec/s'} =~ s/,$//;
 				$devices_stat{$n}{'wr_sec/s'} =~ s/,$//;
 				$fh->print( &jqplot_linegraph_array($IDX++, 'device-read_write', $data_info, $n, $devices_stat{$n}{'rd_sec/s'}, $devices_stat{$n}{'wr_sec/s'}) );
@@ -9879,7 +9879,7 @@ sub compute_space_device_report
 	my %devices_stat = ();
 	foreach my $t (sort {$a <=> $b} keys %sar_space_devices_stat) {
 		foreach my $dev (keys %{$sar_space_devices_stat{$t}}) {
-			if ($data_info->{name} eq 'system-space') { 
+			if ($data_info->{name} eq 'system-space') {
 				$OVERALL_STATS{'system'}{'space'}{$dev}{'fsused'} = $sar_space_devices_stat{$t}{$dev}{'%fsused'} if (!exists $OVERALL_STATS{'system'}{'space'}{$dev}{'fsused'} || $sar_space_devices_stat{$t}{$dev}{'%fsused'} > $OVERALL_STATS{'system'}{'space'}{$dev}{'fsused'});
 				$OVERALL_STATS{'system'}{'space'}{$dev}{'iused'} = $sar_space_devices_stat{$t}{$dev}{'%iused'} if (!exists $OVERALL_STATS{'system'}{'space'}{$dev}{'iused'} || $sar_space_devices_stat{$t}{$dev}{'%iused'} > $OVERALL_STATS{'system'}{'space'}{$dev}{'iused'});
 				$devices_stat{$dev}{'%fsused'} .= '[' . $t . ',' . $sar_space_devices_stat{$t}{$dev}{'%fsused'} . '],';
@@ -9901,7 +9901,7 @@ sub compute_space_device_report
 			}
 			&html_header($fh, $src_base);
 			$fh->print("<ul id=\"slides\">\n");
-			if ($data_info->{name} eq 'system-space') { 
+			if ($data_info->{name} eq 'system-space') {
 				$devices_stat{$n}{'%fsused'} =~ s/,$//;
 				$devices_stat{$n}{'%iused'} =~ s/,$//;
 				$fh->print( &jqplot_linegraph_array($IDX++, 'device-space', $data_info, $n, $devices_stat{$n}{'%fsused'}, $devices_stat{$n}{'%iused'}) );
@@ -10015,7 +10015,7 @@ sub compute_network_report
 		}
 	}
 	%sar_networks_stat = ();
-	
+
 	if (scalar keys %networks_stat > 0) {
 		foreach my $n (sort { $a cmp $b } keys %networks_stat) {
 
@@ -11692,7 +11692,7 @@ sub convert_sar_time
 		} elsif ($am_pm && ($am_pm eq 'PM')) {
 			$h += 12 if ($h < 12);
 		}
-			
+
 		my $time = ($h*3600)+($m*60)+$s;
 
 		my $tz = ((0-$TIMEZONE)*3600);
@@ -11733,7 +11733,7 @@ sub convert_pidstat_time
 		} elsif ($am_pm && ($am_pm eq 'PM')) {
 			$h += 12 if ($h < 12);
 		}
-			
+
 		my $time = ($h*3600)+($m*60)+$s;
 
 		my $tz = ((0-$TIMEZONE)*3600);
@@ -12268,7 +12268,7 @@ sub clear_stats
 	%sysinfo = ();
 	foreach my $name (@sar_to_be_stored) {
 		%{$name} = ();
-	}		
+	}
 
 }
 
@@ -12656,7 +12656,7 @@ sub build_incremental_index
 sub IsLeapYear
 {
 	return ((($_[0] & 3) == 0) && (($_[0] % 100 != 0) || ($_[0] % 400 == 0)));
-} 
+}
 
 sub get_calendar
 {

--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -541,7 +541,7 @@ if ($LIST_METRIC)
 	print "List of available metrics:\n\n";
 	foreach my $c (sort {$a cmp $b} keys %METRICS_COMMANDS)
 	{
-		next if (($c =~ /^(user|all)_/) && ($c !~ /^$STAT_TYPE/)); 
+		next if (($c =~ /^(user|all)_/) && ($c !~ /^$STAT_TYPE/));
 		$c =~ s/_stats$//;
 		print "\t$c\n";
 	}
@@ -664,7 +664,7 @@ else
 my $def_sar_command = "LC_ALL=C $SAR_PROG -t -p -A 1 1 | grep -vE 'Average|Summary'";
 my $def_pidstat_command = "LC_ALL=C $PIDSTAT_PROG -T ALL -u -w -r -d -U postgres 1 1 | grep -v 'Average'";
 my $sshcmd = '';
-# Set command to execute sar remotely using ssh if necessary 
+# Set command to execute sar remotely using ssh if necessary
 if ($USE_SSH)
 {
 	# Force using the user defined ssh command
@@ -722,7 +722,7 @@ sub terminate
 	exit 0;
 }
 
-# Die on kill -2, -3 or -15 
+# Die on kill -2, -3 or -15
 $SIG{'INT'} = $SIG{'QUIT'} = $SIG{'TERM'} = \&terminate;
 
 # Run in interactive mode if required
@@ -871,7 +871,7 @@ while (1)
 		});
 	}
 
-	# Set daily rotation subdirectories 
+	# Set daily rotation subdirectories
 	if ($D_ROTATE && !$H_ROTATE && !-d "$year/$mon/$mday") {
 		mkdir("$year") if (!-d "$year");
 		mkdir("$year/$mon") if (!-d "$year/$mon");
@@ -891,7 +891,7 @@ while (1)
 		});
 	}
 
-	# Set hourly rotation/incremental subdirectories 
+	# Set hourly rotation/incremental subdirectories
 	if ($H_ROTATE && !-d "$year/$mon/$mday/$hour") {
 		mkdir("$year") if (!-d "$year");
 		mkdir("$year/$mon") if (!-d "$year/$mon");
@@ -913,11 +913,11 @@ while (1)
 		# year overlap.
 		$year--;
 		if (-d "$OUTPUT_DIR/$year") {
-			`find $OUTPUT_DIR/$year/ -name '*' -mtime +$RETENTION -delete`;
+			`find '$OUTPUT_DIR/$year/' -name '*' -mtime +$RETENTION -delete`;
 		}
 		$year++;
 		if (-d "$OUTPUT_DIR/$year") {
-			`find $OUTPUT_DIR/$year/ -name '*' -mtime +$RETENTION -delete`;
+			`find '$OUTPUT_DIR/$year/' -name '*' -mtime +$RETENTION -delete`;
 		}
 	}
 
@@ -927,9 +927,9 @@ while (1)
 	if (!$DISABLE_SAR  && $sysstat_version)
 	{
 		$sar_command = ($sshcmd) ? $sshcmd . ' "' . $def_sar_command . ' "' : $def_sar_command;
-		$sar_command .= " >>$OUT_DIR/$SAR_FILE";
+		$sar_command .= " >>'$OUT_DIR/$SAR_FILE'";
 		$pidstat_command = ($sshcmd) ? $sshcmd . ' "' . $def_pidstat_command . ' "' : $def_pidstat_command;
-		$pidstat_command .= " >>$OUT_DIR/$PIDSTAT_FILE";
+		$pidstat_command .= " >>'$OUT_DIR/$PIDSTAT_FILE'";
 
 		# Start processes to collect system statistics permanently
 		&spawn_sar(sub {
@@ -957,7 +957,7 @@ while (1)
 		# Lookup if output dir size is upper than limit
 		if ($MAX_SIZE)
 		{
-			my $lsize = `du -s $OUTPUT_DIR`;
+			my $lsize = `du -s '$OUTPUT_DIR'`;
 			chomp($lsize);
 			if ($lsize > $MAX_SIZE) {
 				unlink_pid_and_exit("LOG: max size limit reach, terminating.", 0);
@@ -997,11 +997,11 @@ if ($CAPTURE) {
 	chdir($CAPTURE_DIR);
 	# Then create a tarball before removing the output directory
 	print "INFO: creating archive $CAPTURE_DIR/pgcluu_capture.tar.gz of the capture directory $CAPTURE_DIR/$OUTPUT_DIR.\n";
-	`$TAR_PROG pgcluu_capture.tar.gz $OUTPUT_DIR`;
+	`$TAR_PROG pgcluu_capture.tar.gz '$OUTPUT_DIR'`;
 	# Removing temporary directory and ensure that we are not removing anything else
 	print "INFO: removing capture temporary directory: $CAPTURE_DIR/$OUTPUT_DIR\n";
 	if ($OUTPUT_DIR eq 'pgcluu_capture') {
-		`rm -rf $OUTPUT_DIR`;
+		`rm -rf '$OUTPUT_DIR'`;
 	}
 }
 
@@ -1084,9 +1084,9 @@ sub collect_metrics
 				rename ("$OUT_DIR/$filename","$OUT_DIR/$filename.tmpold");
 			}
 			if ($sshcmd) {
-				`$sshcmd "$CAT_PROG $f" >$outdir/$filename 2>/dev/null`;
+				`$sshcmd "$CAT_PROG $f" >"$outdir/$filename" 2>/dev/null`;
 			} else {
-				`$CAT_PROG $f >$outdir/$filename 2>/dev/null`;
+				`$CAT_PROG $f >"$outdir/$filename" 2>/dev/null`;
 			}
 			if (-z "$OUT_DIR/$filename") {
 				# remove file when empty
@@ -1112,7 +1112,7 @@ sub collect_metrics
 		}
 	}
 
-	# Generating global statistics collector SQL script 
+	# Generating global statistics collector SQL script
 	my $script_sql = &create_sql_script();
 	if (!$script_sql && ($#METRICS < 0))
 	{
@@ -1135,7 +1135,7 @@ sub collect_metrics
 			my @dblist = &get_databases();
 			push(@dblist, $DBNAME) if (($#dblist == -1) && $DBNAME);
 
-			# Generating per database statistics collector SQL script 
+			# Generating per database statistics collector SQL script
 			foreach my $db (@dblist)
 			{
 
@@ -1202,9 +1202,9 @@ sub collect_metrics
 				}
 				die "FATAL: no SQL with metric command pgbouncer_stats ($sql).\n" if (!$sql || $@);
 			}
-			`$PGBOUNCER_PROG -c "$sql" | sed 's/^/$timestamp;/' $FILE_REDIR $OUT_DIR/$METRICS_COMMANDS{$c}->{output}`;
+			`$PGBOUNCER_PROG -c "$sql" | sed 's/^/$timestamp;/' $FILE_REDIR '$OUT_DIR/$METRICS_COMMANDS{$c}->{output}'`;
 			if ($? != 0) {
-				&dprint("LOG: $PGBOUNCER_PROG -c \"$sql\" | sed 's/^/$timestamp;/' $FILE_REDIR $OUT_DIR/$METRICS_COMMANDS{$c}->{output}\n");
+				&dprint("LOG: $PGBOUNCER_PROG -c \"$sql\" | sed 's/^/$timestamp;/' $FILE_REDIR '$OUT_DIR/$METRICS_COMMANDS{$c}->{output}'\n");
 				&dprint("ERROR: pgbouncer pool query failure, $!\n");
 			}
 		}
@@ -1232,7 +1232,7 @@ sub collect_metrics
 
 	# Override sysinfo.txt to be atomic
 	if (-e "$OUT_DIR/sysinfo.txt.tmp") {
-		`mv -f $OUT_DIR/sysinfo.txt.tmp $OUT_DIR/sysinfo.txt`;
+		`mv -f '$OUT_DIR/sysinfo.txt.tmp' '$OUT_DIR/sysinfo.txt'`;
 	}
 }
 
@@ -1410,7 +1410,7 @@ sub verify_action
 		delete $METRICS_COMMANDS{'database_usagecount_stats'};
 		delete $METRICS_COMMANDS{'relation_buffercache_stats'};
 		delete $METRICS_COMMANDS{'database_isdirty_stats'};
-	} 
+	}
 
 	return $ret;
 }
@@ -1426,7 +1426,7 @@ sub create_sql_script
 		next if (!$db && $METRICS_COMMANDS{$type}->{repeat});
 		next if ($db && !$METRICS_COMMANDS{$type}->{repeat});
 		next if ($type =~ /^pgbouncer_|configuration_/);
-		next if (($type =~ /^(user|all)_/) && ($type !~ /^$STAT_TYPE/)); 
+		next if (($type =~ /^(user|all)_/) && ($type !~ /^$STAT_TYPE/));
 		next if (($#METRICS >= 0) && !grep(/^$type$/, @METRICS));
 		# Look if there is the pg_wait_sampling extension in this database
 		if ($type eq 'waitevent_stats')
@@ -1456,7 +1456,7 @@ sub create_sql_script
 \\o | cat > /dev/null
 $ALWAYS_SECURE_SEARCH_PATH_SQL
 -- $type
-\\o | cat $FILE_REDIR $OUT_DIR/$file_output
+\\o | cat $FILE_REDIR '$OUT_DIR/$file_output'
 COPY ($sql) TO STDOUT CSV DELIMITER ';';
 
 EOF
@@ -1467,7 +1467,7 @@ EOF
 \\o | cat > /dev/null
 $ALWAYS_SECURE_SEARCH_PATH_SQL
 -- $type
-\\o | cat $FILE_REDIR $OUT_DIR/$file_output
+\\o | cat $FILE_REDIR '$OUT_DIR/$file_output'
 BEGIN;
 CREATE TEMPORARY TABLE __pgcluu as $sql;
 COPY __pgcluu TO STDOUT CSV DELIMITER ';';
@@ -1928,7 +1928,7 @@ sub grab_os_information
 	print $fhl @crontab;
 	print $fhl "[INSTALLATION]\n";
 	print $fhl @installation;
-	
+
 	close($fhl);
 }
 
@@ -1952,7 +1952,7 @@ options:
   -E, --end-after=NUM      self terminate the program after a given number of
                            seconds. Can be written: 7200 or 120M or 2H, for
 			   days use 7D for example to stop collecting data
-			   after seven days. 
+			   after seven days.
   -f, --pid-file=FILE      path to pid file. Default: $PIDFILE.
   -h, --host=HOSTNAME      database server host or socket directory
   -i, --interval=NUM       time to wait between runs
@@ -1960,7 +1960,7 @@ options:
   -m, --metric=METRIC      set a coma separated list of metrics to perform.
   -M, --max-size=SIZE      self terminate program when the size of the output
                            directory exceed a given size. Can be written: 2GB
-                           or 2000MB. 
+                           or 2000MB.
   -p, --port=PORT          database port(s) to connect to. Defaults to 5432.
   -P, --psql=BIN           path to the psql command. Default: $PSQL_PROG.
   -Q, --no-statement       do not collect statistics from pg_stat_statements.
@@ -1982,7 +1982,7 @@ options:
                            in a comma separated list of database names.
   --list-metric            list available metrics actions that can be performed.
   --sysinfo                get operating system infos and exit (sysinfo.txt).
-  --no-sysinfo             do not collect operating system information at all. 
+  --no-sysinfo             do not collect operating system information at all.
   --no-database            do not collect database statistics at all.
   --pgbouncer-args=OPTIONS Option to used to connect to the pgbouncer system
 			   database. Ex: -p 6432 -U postgres -h 192.168.1.100
@@ -2252,7 +2252,7 @@ sub dump_pgstatiotables
 	$type ||= 'all';
 
 	my $sql = sprintf(
-		"SELECT date_trunc('seconds', now()), current_database(), * " . 
+		"SELECT date_trunc('seconds', now()), current_database(), * " .
 		"FROM pg_statio_${type}_tables " .
 		"WHERE schemaname <> 'information_schema' " .
 		"ORDER BY schemaname, relname"
@@ -2301,7 +2301,7 @@ sub dump_pgstatuserfunctions
 {
 
 	my $sql = sprintf(
-		"SELECT date_trunc('seconds', now()), current_database(), * " . 
+		"SELECT date_trunc('seconds', now()), current_database(), * " .
 		"FROM pg_stat_user_functions " .
 		"WHERE schemaname <> 'information_schema' " .
 		"ORDER BY schemaname, funcname"
@@ -2509,7 +2509,7 @@ sub dump_pgbouncerquerystats
 
 sub get_current_timestamp
 {
-	
+
 	my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
 
 	$year += 1900;
@@ -2523,7 +2523,7 @@ sub dump_pgstatxactuserfunctions
 {
 
 	my $sql = sprintf(
-		"SELECT date_trunc('seconds', now()), * " . 
+		"SELECT date_trunc('seconds', now()), * " .
 		"FROM pg_stat_xact_user_functions " .
 		"WHERE schemaname <> 'information_schema' " .
 		"ORDER BY 3, 4"
@@ -2541,7 +2541,7 @@ sub dump_pgstatxacttables
 	$type ||= 'all';
 
 	my $sql = sprintf(
-		"SELECT date_trunc('seconds', now()), * " . 
+		"SELECT date_trunc('seconds', now()), * " .
 		"FROM pg_stat_xact_${type}_tables " .
 		"WHERE schemaname <> 'information_schema' " .
 		"ORDER BY 3, 4"
@@ -2648,21 +2648,21 @@ sub dump_redundantindexes
 
 	my $sql =
 		"SELECT date_trunc('seconds', now()), current_database(), " .
-		"pg_get_indexdef(indexrelid) AS contained, " . 
-		"pg_get_indexdef(index_backward) AS container " . 
-		"FROM " . 
-		"( " . 
-		"  SELECT indexrelid, " . 
-		"    indrelid, " . 
-		"    array_to_string(indkey,'+') AS colindex, " . 
-		"    indisunique AS is_unique, " . 
-		"    lag(array_to_string(indkey,'+')) OVER search_window AS colindexbackward, " . 
-		"    lag(indexrelid) OVER search_window AS index_backward, " . 
-		"    lag(indisunique) OVER search_window AS is_unique_backward " . 
-		"  FROM pg_index " . 
-		"    WINDOW search_window AS (PARTITION BY indrelid " . 
-		"    ORDER BY array_to_string(indkey,'+') DESC) " . 
-		") AS tmp " . 
+		"pg_get_indexdef(indexrelid) AS contained, " .
+		"pg_get_indexdef(index_backward) AS container " .
+		"FROM " .
+		"( " .
+		"  SELECT indexrelid, " .
+		"    indrelid, " .
+		"    array_to_string(indkey,'+') AS colindex, " .
+		"    indisunique AS is_unique, " .
+		"    lag(array_to_string(indkey,'+')) OVER search_window AS colindexbackward, " .
+		"    lag(indexrelid) OVER search_window AS index_backward, " .
+		"    lag(indisunique) OVER search_window AS is_unique_backward " .
+		"  FROM pg_index " .
+		"    WINDOW search_window AS (PARTITION BY indrelid " .
+		"    ORDER BY array_to_string(indkey,'+') DESC) " .
+		") AS tmp " .
 		"WHERE (colindexbackward LIKE (colindex || '+%') OR colindexbackward = colindex) " .
 		"  AND (is_unique_backward <> is_unique OR (not is_unique_backward AND NOT is_unique)) " .
 		"  AND NOT is_unique";
@@ -2694,7 +2694,7 @@ sub dump_invalidindexes
 sub dump_hashindexes
 {
 
-        my $sql = 
+        my $sql =
 		"WITH indexes AS ( " .
 		"SELECT date_trunc('seconds', now()), current_database(), schemaname, relname, indexrelname, pg_get_indexdef(pg_stat_user_indexes.indexrelid) " .
 		"FROM pg_stat_user_indexes " .
@@ -2756,7 +2756,7 @@ sub dump_pgsettings
 		"SELECT date_trunc('seconds', now()), category, name, " .
 		" (CASE WHEN name = 'lock_timeout' THEN (setting::bigint-$lto)::text ELSE setting END) as setting," .
 	        " %s, context, source, %s, %s, %s " .
-		"FROM pg_settings " . 
+		"FROM pg_settings " .
 		"ORDER BY category,name",
 		&backend_minimum_version(8, 2) ? "unit" : "''::text as unit",
 		&backend_minimum_version(8, 4) ? "boot_val" : "''::text as boot_val",
@@ -2853,28 +2853,28 @@ sub dump_missingfkindexes
 
 	my $sql = sprintf(
 		"SELECT date_trunc('seconds', now()), current_database(), relname, " .
-		"'CREATE INDEX CONCURRENTLY idx_' || relname || '_' || " . 
-		"         array_to_string(column_name_list, '_') || ' ON ' || conrelid || " . 
-		"         ' (' || array_to_string(column_name_list, ',') || ')' AS ddl " . 
-		"FROM (SELECT DISTINCT conrelid, " . 
-		"       array_agg(attname) AS column_name_list, " . 
-		"       array_agg(attnum) AS column_list " . 
-		"     FROM pg_attribute " . 
-		"          JOIN (SELECT conrelid::regclass, conname, " . 
-		"                 unnest(conkey) AS column_index " . 
-		"                FROM (SELECT DISTINCT conrelid, conname, conkey " . 
-		"                      FROM pg_constraint " . 
-		"                        JOIN pg_class ON pg_class.oid = pg_constraint.conrelid " . 
-		"                        JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace " . 
-		"                      WHERE nspname !~ '^pg_' AND nspname <> 'information_schema' AND pg_constraint.contype = 'f' " . 
-		"                      ) fkey " . 
-		"               ) fkey " . 
-		"               ON fkey.conrelid = pg_attribute.attrelid " . 
-		"                  AND fkey.column_index = pg_attribute.attnum " . 
-		"     GROUP BY conrelid, conname " . 
-		"     ) candidate_index " . 
-		"JOIN pg_class ON pg_class.oid = candidate_index.conrelid " . 
-		"LEFT JOIN pg_index ON pg_index.indrelid = conrelid " . 
+		"'CREATE INDEX CONCURRENTLY idx_' || relname || '_' || " .
+		"         array_to_string(column_name_list, '_') || ' ON ' || conrelid || " .
+		"         ' (' || array_to_string(column_name_list, ',') || ')' AS ddl " .
+		"FROM (SELECT DISTINCT conrelid, " .
+		"       array_agg(attname) AS column_name_list, " .
+		"       array_agg(attnum) AS column_list " .
+		"     FROM pg_attribute " .
+		"          JOIN (SELECT conrelid::regclass, conname, " .
+		"                 unnest(conkey) AS column_index " .
+		"                FROM (SELECT DISTINCT conrelid, conname, conkey " .
+		"                      FROM pg_constraint " .
+		"                        JOIN pg_class ON pg_class.oid = pg_constraint.conrelid " .
+		"                        JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace " .
+		"                      WHERE nspname !~ '^pg_' AND nspname <> 'information_schema' AND pg_constraint.contype = 'f' " .
+		"                      ) fkey " .
+		"               ) fkey " .
+		"               ON fkey.conrelid = pg_attribute.attrelid " .
+		"                  AND fkey.column_index = pg_attribute.attnum " .
+		"     GROUP BY conrelid, conname " .
+		"     ) candidate_index " .
+		"JOIN pg_class ON pg_class.oid = candidate_index.conrelid " .
+		"LEFT JOIN pg_index ON pg_index.indrelid = conrelid " .
 		"                      AND indkey::text = array_to_string(column_list, ' ') " .
 		"WHERE pg_index.indrelid IS NULL "
 	);
@@ -2895,7 +2895,7 @@ sub dump_pgdatabase_buffercache
 		"round(100.0 * count(*) / (SELECT setting FROM pg_settings " .
 		"  WHERE name='shared_buffers')::integer,1) AS \"buffers %\", " .
 		"round(100.0 * count(*) * 8192 / pg_database_size(d.datname),1) AS \"database %\" " .
-		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " . 
+		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " .
 		"GROUP BY d.datname " .
 		"ORDER BY 2,3 DESC"
 	);
@@ -2916,7 +2916,7 @@ sub dump_pgrelation_buffercache
 		"round(100.0 * count(*) / (SELECT setting FROM pg_settings " .
 		"  WHERE name='shared_buffers')::integer,1) AS \"buffers %\", " .
 		"round(100.0 * count(*) * 8192 / pg_relation_size(c.oid),1) AS \"relation %\" " .
-		"FROM pg_class c INNER JOIN public.pg_buffercache b ON b.relfilenode=c.relfilenode " . 
+		"FROM pg_class c INNER JOIN public.pg_buffercache b ON b.relfilenode=c.relfilenode " .
 		"INNER JOIN pg_database d ON ( b.reldatabase=d.oid ) " .
 		"WHERE pg_relation_size(c.oid) > 0 " .
 #		"AND c.relname !~ '^pg_' " .
@@ -2938,7 +2938,7 @@ sub dump_pgdatabase_usercount
 		"SELECT date_trunc('seconds', now()), d.datname, usagecount, " .
 		"count(*) AS buffers, round(100.0 * count(*) / (SELECT setting FROM pg_settings " .
 		"  WHERE name='shared_buffers')::integer,1) AS \"buffers %\" " .
-		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " . 
+		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " .
 		"GROUP BY d.datname, usagecount " .
 		"ORDER BY 2,3 DESC"
 	);
@@ -2956,7 +2956,7 @@ sub dump_pgdatabase_isdirty
 		"SELECT date_trunc('seconds', now()), d.datname, usagecount, isdirty, " .
 		"count(*) AS buffers, round(100.0 * count(*) / (SELECT setting FROM pg_settings " .
 		"  WHERE name='shared_buffers')::integer,1) AS \"buffers %\" " .
-		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " . 
+		"FROM pg_database d INNER JOIN public.pg_buffercache b ON b.reldatabase=d.oid " .
 		"GROUP BY d.datname, usagecount, isdirty " .
 		"ORDER BY 2,3,4 DESC"
 	);
@@ -2971,7 +2971,7 @@ sub dump_pgstatarchiver
 
 	my $sql = sprintf(
 		"SELECT date_trunc('seconds', now()), archived_count, last_archived_wal, " .
-		"last_archived_time, failed_count, last_failed_wal, last_failed_time, stats_reset " . 
+		"last_archived_time, failed_count, last_failed_wal, last_failed_time, stats_reset " .
 		"FROM pg_stat_archiver"
 	);
 
@@ -3314,4 +3314,3 @@ sub read_conf
 		}
 	}
 }
-


### PR DESCRIPTION
New MR to fix #138 issue : 

 Fix in pgcluu for OUTPUT_DIR like vars always be quoted (when used in external command calls), especially if their value may contain a whitespace or separator character.


