### PR TITLE
Add a comment in the CREATE INDEX when the suggested index may be red…

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -2854,30 +2854,39 @@ sub dump_missingfkindexes
 
 	my $sql = sprintf(
 		"SELECT date_trunc('seconds', now()), current_database(), relname, " .
-		"'CREATE INDEX CONCURRENTLY idx_' || relname || '_' || " .
-		"         array_to_string(column_name_list, '_') || ' ON ' || conrelid || " .
-		"         ' (' || array_to_string(column_name_list, ',') || ')' AS ddl " .
-		"FROM (SELECT DISTINCT conrelid, " .
-		"       array_agg(attname) AS column_name_list, " .
-		"       array_agg(attnum) AS column_list " .
-		"     FROM pg_attribute " .
-		"          JOIN (SELECT conrelid::regclass, conname, " .
-		"                 unnest(conkey) AS column_index " .
-		"                FROM (SELECT DISTINCT conrelid, conname, conkey " .
-		"                      FROM pg_constraint " .
-		"                        JOIN pg_class ON pg_class.oid = pg_constraint.conrelid " .
-		"                        JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace " .
-		"                      WHERE nspname !~ '^pg_' AND nspname <> 'information_schema' AND pg_constraint.contype = 'f' " .
-		"                      ) fkey " .
-		"               ) fkey " .
-		"               ON fkey.conrelid = pg_attribute.attrelid " .
-		"                  AND fkey.column_index = pg_attribute.attnum " .
-		"     GROUP BY conrelid, conname " .
-		"     ) candidate_index " .
-		"JOIN pg_class ON pg_class.oid = candidate_index.conrelid " .
-		"LEFT JOIN pg_index ON pg_index.indrelid = conrelid " .
-		"                      AND indkey::text = array_to_string(column_list, ' ') " .
-		"WHERE pg_index.indrelid IS NULL "
+"'CREATE INDEX CONCURRENTLY idx_' || relname || '_' ||
+         array_to_string(column_name_list, '_') || ' ON ' || conrelid ||
+         ' (' || array_to_string(column_name_list, ',') || ')'
+         || CASE WHEN COUNT(DISTINCT redi.indexrelid) >0 THEN '  /* maybe redundant with: '|| string_agg (redi.indexrelid::regclass::text,', ') || ' */' ELSE '' END
+         AS ddl
+FROM (SELECT DISTINCT conrelid,
+       array_agg(attname) AS column_name_list,
+       array_agg(attnum) AS column_list
+     FROM pg_attribute
+          JOIN (-- existing constraints
+                SELECT conrelid::regclass, conname,
+                 unnest(conkey) AS column_index
+                FROM (SELECT DISTINCT conrelid, conname, conkey
+                      FROM pg_constraint
+                        JOIN pg_class ON pg_class.oid = pg_constraint.conrelid
+                        JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+                      WHERE nspname !~ '^pg_' AND nspname <> 'information_schema' AND pg_constraint.contype = 'f'
+                      ) fkey
+               ) fkey
+               ON fkey.conrelid = pg_attribute.attrelid
+                  AND fkey.column_index = pg_attribute.attnum
+     GROUP BY conrelid, conname
+     ) candidate_index
+JOIN pg_class ON pg_class.oid = candidate_index.conrelid
+LEFT JOIN pg_index i ON i.indrelid = conrelid
+                      AND i.indkey::text = array_to_string(column_list, ' ')
+-- potentially redundant existing indexes
+LEFT JOIN pg_index redi ON redi.indrelid = conrelid
+                       AND column_list  <@ redi.indkey::smallint[] -- contains
+                       AND redi.indkey::text != array_to_string(column_list, ' ')
+WHERE i.indrelid IS NULL
+GROUP BY relname, conrelid, column_name_list
+ORDER BY ddl"
 	);
 
 	return $sql;


### PR DESCRIPTION
…undant with existing ones.

Suggested missing indexes on FK may be redundant with other ones
(typically: an index with more columns already exists).
Add a comment in the DDL pointing to these indexes,
so the DBA can decide itself if the new index is worth it or not.
There is no check with other suggested indexes that do not exist yet.

I've removed all the ".   that make cut-and-paste a torture.

Closes #151 