### PR TITLE
[pgcluu_collectd] dump pg_stats view

### DIFF
--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -72,6 +72,7 @@ my @SKIP_END    = ();
 my $USE_BUFFERCACHE = 0;
 my $NO_STATEMENTS  = 0;
 my $NO_WAITEVENT  = 0;
+my $NO_PGSTATS_DUMP  = 0;
 my $NO_SYSINFO  = 0;
 my $SHOW_VER    = 0;
 my $END_AFTER   = 0;
@@ -427,6 +428,7 @@ my $result = GetOptions(
 	"v|verbose!"     => \$DEBUG,
 	"V|version!"     => \$SHOW_VER,
 	"w|no-waitevent!"=> \$NO_WAITEVENT,
+	"n|no-pg_stats-dump!"=> \$NO_PGSTATS_DUMP,
 	"W|password=s"   => \$DBPASS,
 	"z|compress!"    => \$COMPRESS,
 	"pgversion=s"    => \$PG_VERSION,
@@ -1510,6 +1512,10 @@ sub create_sql_script
 			next if (!$db || $NO_WAITEVENT);
 			next if (!grep(/^$db=.*pg_wait_sampling/, @extensions));
 		}
+		if ($type eq 'stats_stats')
+		{
+			next if (!$db || $NO_PGSTATS_DUMP);
+		}
 
 		# Get the SQL command to execute for this metric
 		my $sql = $METRICS_COMMANDS{$type}->{command}->();
@@ -2056,6 +2062,7 @@ options:
   -v, --verbose            Print out debug informations.
   -V, --version            Show pgcluu_collectd version and exit.
   -w, --no-waitevent       don't collect wait event stats from pg_wait_sampling.
+  -n, --no-pg_stats-dump   don't collect statistics from the pg_stats view.
   -W, --password=pass      database password.
   -z, --compress           force compression of rotated data files.
   --included-db=DATABASE   collect statistics only for those databases present

--- a/pgcluu_collectd
+++ b/pgcluu_collectd
@@ -387,6 +387,12 @@ my %METRICS_COMMANDS = (
 		'repeat'  => 1,
 		'override'  => 1,
 	},
+	'stats_stats' => {
+		'output' => 'pg_stats.csv',
+		'command' => 'dump_pg_stats_view',
+		'repeat'  => 1,
+		'start-end' => 1,
+	},
 );
 
 # Read configuration file before reading command line parameters
@@ -2289,6 +2295,22 @@ sub dump_pgstattables
 		&backend_minimum_version(8, 3) ? ", n_tup_hot_upd, n_live_tup, n_dead_tup" : "",
 		&backend_minimum_version(8, 2) ? ", date_trunc('seconds', last_vacuum) AS last_vacuum, date_trunc('seconds', last_autovacuum) AS last_autovacuum, date_trunc('seconds',last_analyze) AS last_analyze, date_trunc('seconds',last_autoanalyze) AS last_autoanalyze" : "",
 		&backend_minimum_version(9, 1) ? ", vacuum_count, autovacuum_count, analyze_count, autoanalyze_count" : ""
+	);
+
+	return $sql;
+}
+
+sub dump_pg_stats_view
+{
+	my $sql = sprintf(
+		"SELECT date_trunc('seconds', now()), current_database(), schemaname, tablename, attname, " .
+		"%s" .
+		"null_frac, avg_width, n_distinct, " .
+		"most_common_vals, most_common_freqs, " .
+		"histogram_bounds, correlation" .
+		" FROM pg_stats " .
+		"WHERE schemaname NOT IN ('pg_catalog', 'information_schema')",
+		&backend_minimum_version(9, 0) ? "inherited, " : "",
 	);
 
 	return $sql;


### PR DESCRIPTION
It is useful to dump the pg_stats views. The dump can be imported in a table created like this:

CREATE TABLE my_client_pgstats (
  export_time TEXT,
  dbname TEXT,
  schemaname TEXT,
  tablename TEXT,
  attname TEXT,
  inherited BOOLEAN,
  null_frac REAL,
  avg_width INT,
  n_distinct REAL,
  most_common_vals TEXT[],
  most_common_freqs REAL[],
  histogram_bounds TEXT[],
  correlation REAL
);

Note that the columns most_common_vals and histogram_bounds have the type TEXT[] instead of anyarray.

The point is for the DBA to study the statistics, and nothing else.